### PR TITLE
Execute thread manager when multithreading is enabled

### DIFF
--- a/source/Jitter/Collision/CollisionSystemPersistentSAP.cs
+++ b/source/Jitter/Collision/CollisionSystemPersistentSAP.cs
@@ -318,7 +318,8 @@ namespace Jitter.Collision
                 }
             }
 
-            threadManager.Execute();
+            if (multiThreaded)
+                threadManager.Execute();
 
         }
 


### PR DESCRIPTION
`ThreadManager` is being used even if multithread is not enabled.